### PR TITLE
feat: http2 headers pass-through via pre-allocated buffer, fast api calls

### DIFF
--- a/benchmark/http2/map.js
+++ b/benchmark/http2/map.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const common = require('../common.js');
+
+const bench = common.createBenchmark(main, {
+  n: [1e3],
+  nheaders: [0, 10, 100, 1000],
+}, { flags: ['--no-warnings', '--expose-internals'] });
+
+function main({ n, nheaders }) {
+  const { mapToHeaders } = require('internal/http2/util');
+
+  const headersObject = {
+    ':path': '/',
+    ':scheme': 'http',
+    'accept-encoding': 'gzip, deflate',
+    'accept-language': 'en',
+    'content-type': 'text/plain',
+    'referer': 'https://example.org/',
+    'user-agent': 'SuperBenchmarker 3000',
+  };
+
+  for (let i = 0; i < nheaders; i++) {
+    headersObject[`foo${i}`] = `some header value ${i}`;
+  }
+
+  bench.start();
+  for (let i = 0; i < n; i += 1) {
+    // we can optimize this more, but it's irrelevant as we need something
+    // better to be passed on to c++ side
+    const remapped = mapToHeaders(headersObject)
+  }
+  bench.end(n);
+}

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -152,6 +152,7 @@ const {
   kRequest,
   kProxySocket,
   mapToHeaders,
+  prepareHeaders,
   MAX_ADDITIONAL_SETTINGS,
   NghttpError,
   remoteCustomSettingsToBuffer,
@@ -178,6 +179,11 @@ const { format } = require('internal/util/inspect');
 
 const { FileHandle } = internalBinding('fs');
 const binding = internalBinding('http2');
+const {
+  respondStatic,
+  idStatic,
+  trailersStatic
+} = binding;
 const {
   ShutdownWrap,
   kReadBytesOrError,
@@ -726,8 +732,10 @@ function requestOnConnect(headers, options) {
 
   // `ret` will be either the reserved stream ID (if positive)
   // or an error code (if negative)
-  const ret = session[kHandle].request(headers,
-                                       streamOptions,
+  prepareHeaders(headers);
+
+  // issue the request
+  const ret = session[kHandle].request(streamOptions,
                                        options.parent | 0,
                                        options.weight | 0,
                                        !!options.exclusive);
@@ -757,7 +765,8 @@ function requestOnConnect(headers, options) {
     }
     return;
   }
-  this[kInit](ret.id(), ret);
+
+  this[kInit](idStatic(ret), ret);
 }
 
 // Validates that priority options are correct, specifically:
@@ -1797,13 +1806,12 @@ class ClientHttp2Session extends Http2Session {
       validateBoolean(options.endStream, 'options.endStream');
     }
 
-    const headersList = mapToHeaders(headers);
 
     // eslint-disable-next-line no-use-before-define
     const stream = new ClientHttp2Stream(this, undefined, undefined, {});
     stream[kSentHeaders] = headers;
     stream[kOrigin] = `${headers[HTTP2_HEADER_SCHEME]}://` +
-                      `${getAuthority(headers)}`;
+    `${getAuthority(headers)}`;
     const reqAsync = new AsyncResource('PendingRequest');
     stream[kRequestAsyncResource] = reqAsync;
 
@@ -1828,7 +1836,7 @@ class ClientHttp2Session extends Http2Session {
       }
     }
 
-    const onConnect = reqAsync.bind(requestOnConnect.bind(stream, headersList, options));
+    const onConnect = reqAsync.bind(requestOnConnect.bind(stream, headers, options));
     if (this.connecting) {
       if (this[kPendingRequestCalls] !== null) {
         this[kPendingRequestCalls].push(onConnect);
@@ -1893,7 +1901,7 @@ function shutdownWritable(callback) {
     return ReflectApply(afterShutdown, req, [0]);
 }
 
-function finishSendTrailers(stream, headersList) {
+function finishSendTrailers(stream, headers) {
   // The stream might be destroyed and in that case
   // there is nothing to do.
   // This can happen because finishSendTrailers is
@@ -1904,7 +1912,8 @@ function finishSendTrailers(stream, headersList) {
 
   stream[kState].flags &= ~STREAM_FLAGS_HAS_TRAILERS;
 
-  const ret = stream[kHandle].trailers(headersList);
+  prepareHeaders(headers, assertValidPseudoHeaderTrailer);
+  const ret = trailersStatic(stream[kHandle]);
   if (ret < 0)
     stream.destroy(new NghttpError(ret));
   else
@@ -2265,11 +2274,11 @@ class Http2Stream extends Duplex {
 
     this[kUpdateTimer]();
 
-    const headersList = mapToHeaders(headers, assertValidPseudoHeaderTrailer);
+    // const headersList = mapToHeaders(headers, assertValidPseudoHeaderTrailer);
     this[kSentTrailers] = headers;
 
     // Send the trailers in setImmediate so we don't do it on nghttp2 stack.
-    setImmediate(finishSendTrailers, this, headersList);
+    setImmediate(finishSendTrailers, this, headers);
   }
 
   get closed() {
@@ -2498,7 +2507,7 @@ function processRespondWithFD(self, fd, headers, offset = 0, length = -1,
 
   let headersList;
   try {
-    headersList = mapToHeaders(headers, assertValidPseudoHeaderResponse);
+    prepareHeaders(headers, assertValidPseudoHeaderResponse);
   } catch (err) {
     self.destroy(err);
     return;
@@ -2510,7 +2519,7 @@ function processRespondWithFD(self, fd, headers, offset = 0, length = -1,
   self._final = null;
   self.end();
 
-  const ret = self[kHandle].respond(headersList, streamOptions);
+  const ret = respondStatic(self[kHandle], streamOptions);
 
   if (ret < 0) {
     self.destroy(new NghttpError(ret));
@@ -2722,11 +2731,10 @@ class ServerHttp2Stream extends Http2Stream {
     if (headers[HTTP2_HEADER_METHOD] === HTTP2_METHOD_HEAD)
       headRequest = options.endStream = true;
 
-    const headersList = mapToHeaders(headers);
-
+    prepareHeaders(headers);
     const streamOptions = options.endStream ? STREAM_OPTION_EMPTY_PAYLOAD : 0;
 
-    const ret = this[kHandle].pushPromise(headersList, streamOptions);
+    const ret = this[kHandle].pushPromise(streamOptions);
     let err;
     if (typeof ret === 'number') {
       switch (ret) {
@@ -2744,7 +2752,7 @@ class ServerHttp2Stream extends Http2Stream {
       return;
     }
 
-    const id = ret.id();
+    const id = idStatic(ret);
     const stream = new ServerHttp2Stream(session, ret, id, options, headers);
     stream[kSentHeaders] = headers;
 
@@ -2786,7 +2794,6 @@ class ServerHttp2Stream extends Http2Stream {
     }
 
     headers = processHeaders(headers, options);
-    const headersList = mapToHeaders(headers, assertValidPseudoHeaderResponse);
     this[kSentHeaders] = headers;
 
     state.flags |= STREAM_FLAGS_HEADERS_SENT;
@@ -2803,7 +2810,13 @@ class ServerHttp2Stream extends Http2Stream {
       this.end();
     }
 
-    const ret = this[kHandle].respond(headersList, streamOptions);
+    // const headersList = mapToHeaders(headers, assertValidPseudoHeaderResponse);
+
+    // `ret` will be either the reserved stream ID (if positive)
+    // or an error code (if negative)
+    prepareHeaders(headers, assertValidPseudoHeaderResponse);
+
+    const ret = respondStatic(this[kHandle], streamOptions);
     if (ret < 0)
       this.destroy(new NghttpError(ret));
   }
@@ -2954,13 +2967,13 @@ class ServerHttp2Stream extends Http2Stream {
 
     this[kUpdateTimer]();
 
-    const headersList = mapToHeaders(headers, assertValidPseudoHeaderResponse);
+    prepareHeaders(headers, assertValidPseudoHeaderResponse);
     if (!this[kInfoHeaders])
       this[kInfoHeaders] = [headers];
     else
       this[kInfoHeaders].push(headers);
 
-    const ret = this[kHandle].info(headersList);
+    const ret = this[kHandle].info();
     if (ret < 0)
       this.destroy(new NghttpError(ret));
   }

--- a/lib/internal/http2/util.js
+++ b/lib/internal/http2/util.js
@@ -13,6 +13,10 @@ const {
   Symbol,
 } = primordials;
 
+const {
+  asciiWriteStatic
+} = internalBinding('buffer');
+
 const binding = internalBinding('http2');
 const {
   codes: {
@@ -569,9 +573,10 @@ function isIllegalConnectionSpecificHeader(name, value) {
     case HTTP2_HEADER_KEEP_ALIVE:
     case HTTP2_HEADER_PROXY_CONNECTION:
     case HTTP2_HEADER_TRANSFER_ENCODING:
-      return true;
+      throw new ERR_HTTP2_INVALID_CONNECTION_HEADERS(key);
     case HTTP2_HEADER_TE:
-      return value !== 'trailers';
+      if (value !== 'trailers')
+        throw new ERR_HTTP2_INVALID_CONNECTION_HEADERS(key);
     default:
       return false;
   }
@@ -642,9 +647,7 @@ function mapToHeaders(map,
       kNeverIndexFlag :
       kNoHeaderFlags;
     if (key[0] === ':') {
-      err = assertValuePseudoHeader(key);
-      if (err !== undefined)
-        throw err;
+      assertValuePseudoHeader(key);
       pseudoHeaders += `${key}\0${value}\0${flags}`;
       count++;
       continue;
@@ -652,9 +655,8 @@ function mapToHeaders(map,
     if (key.includes(' ')) {
       throw new ERR_INVALID_HTTP_TOKEN('Header name', key);
     }
-    if (isIllegalConnectionSpecificHeader(key, value)) {
-      throw new ERR_HTTP2_INVALID_CONNECTION_HEADERS(key);
-    }
+    isIllegalConnectionSpecificHeader(key, value);
+
     if (isArray) {
       for (j = 0; j < value.length; ++j) {
         const val = String(value[j]);
@@ -668,6 +670,130 @@ function mapToHeaders(map,
   }
 
   return [pseudoHeaders + headers, count];
+}
+
+function verifySingles(singles, key) {
+  if (singles.has(key))
+    throw new ERR_HTTP2_HEADER_SINGLE_VALUE(key);
+  singles.add(key);
+}
+
+function createPrepareHeaders() {
+  const singles = new SafeSet();
+  let header;
+  let value;
+  let isArray;
+  let count = 0;
+  let offset = 16; // first 16 bytes for metadata, aligned to 8 bytes
+  let toWrite = 0;
+  let j;
+  let val;
+  let pseudo_headers = 0;
+  let isPseudo = false;
+  let isSingleValueHeader = false;
+
+  let buf = binding.outgoingHeaders;
+  let capacity = buf.length;
+
+  function writeU_Int32LE(value, offset) {
+    buf[offset++] = value;
+    value = value >>> 8;
+    buf[offset++] = value;
+    value = value >>> 8;
+    buf[offset++] = value;
+    value = value >>> 8;
+    buf[offset++] = value;
+    return offset;
+  }
+
+  function writeToBuffer(str) {
+    toWrite = str.length;
+
+    if (toWrite + 2 > capacity - offset) {
+      capacity = Math.max(capacity * 2, capacity + toWrite * 2);
+      binding.increaseBuffer(capacity);
+      buf = binding.outgoingHeaders;
+    }
+
+    offset += asciiWriteStatic(buf, str, offset, toWrite);
+    // offset += buf.write(str, offset, toWrite, 'ascii');
+    buf[offset] = 0;
+    offset += 1;
+  }
+
+  return function prepareHeaders(headers, assertValuePseudoHeader = assertValidPseudoHeader) {
+    singles.clear();
+
+    pseudo_headers = 0;
+    count = 0;
+    offset = 16; // first 16 bytes for metadata, aligned to 8 bytes
+
+    for (header in headers) {
+      value = headers[header];
+      if (value === undefined || header === '')
+        continue;
+
+      isArray = ArrayIsArray(value);
+      isSingleValueHeader = kSingleValueHeaders.has(header);
+      if (isArray) {
+        if (value.length === 0)
+          continue;
+        else if (value.length === 1)
+          value = value[0];
+        else if (isSingleValueHeader)
+          throw new ERR_HTTP2_HEADER_SINGLE_VALUE(header);
+      }
+
+      // -- header
+      writeToBuffer(header);
+      if (header[0] === ':') {
+        assertValuePseudoHeader(header);
+        pseudo_headers += 1;
+      } else if (header.includes(' ')) {
+        throw new ERR_INVALID_HTTP_TOKEN('Header name', header);
+      }
+
+      if (!isArray) {
+        value = typeof value === 'string' ? value : `${value}`
+        writeToBuffer(value);
+        count += 1;
+        if (isSingleValueHeader) {
+          verifySingles(singles, header);
+          isIllegalConnectionSpecificHeader(header, value);
+        }
+      } else {
+        for (j = 0; j <= value.length; j += 1) {
+          val = value[j];
+          writeToBuffer(typeof val === 'string' ? val : `${val}`);
+        }
+        count += value.length;
+      }
+
+      // double 0 means end of name value pairs
+      buf[offset] = 0;
+      offset += 1;
+    }
+
+    // write number of headers
+    if (count > 0) {
+      const neverIndex = (headers[kSensitiveHeaders] || emptyArray);
+      const neverIndexCount = neverIndex.length;
+
+      writeU_Int32LE(count, 0);
+      writeU_Int32LE(offset - 16, 4);
+      writeU_Int32LE(pseudo_headers, 8);
+      writeU_Int32LE(neverIndexCount, 12);
+
+      if (neverIndexCount > 0) {
+        for (j = 0; j < neverIndexCount; j += 1) {
+          writeToBuffer(neverIndex[j]);
+        }
+      }
+    } else {
+      writeU_Int32LE(0, 0);
+    }
+    // console.log(count, offset - 16, pseudo_headers, buf.slice(16).toString('ascii'));
+  }
 }
 
 class NghttpError extends Error {
@@ -804,6 +930,7 @@ module.exports = {
   kProxySocket,
   kRequest,
   mapToHeaders,
+  prepareHeaders: createPrepareHeaders(),
   MAX_ADDITIONAL_SETTINGS,
   NghttpError,
   remoteCustomSettingsToBuffer,

--- a/src/aliased_buffer-inl.h
+++ b/src/aliased_buffer-inl.h
@@ -13,8 +13,9 @@ typedef size_t AliasedBufferIndex;
 
 template <typename NativeT, typename V8T>
 AliasedBufferBase<NativeT, V8T>::AliasedBufferBase(
-    v8::Isolate* isolate, const size_t count, const AliasedBufferIndex* index)
-    : isolate_(isolate), count_(count), byte_offset_(0), index_(index) {
+    v8::Isolate* isolate, const size_t count, const AliasedBufferIndex* index,
+    v8::BackingStoreInitializationMode initialization_mode)
+    : isolate_(isolate), count_(count), index_(index) {
   CHECK_GT(count, 0);
   if (index != nullptr) {
     // Will be deserialized later.
@@ -25,7 +26,7 @@ AliasedBufferBase<NativeT, V8T>::AliasedBufferBase(
       MultiplyWithOverflowCheck(sizeof(NativeT), count);
 
   // allocate v8 ArrayBuffer
-  v8::Local<v8::ArrayBuffer> ab = v8::ArrayBuffer::New(isolate_, size_in_bytes);
+  v8::Local<v8::ArrayBuffer> ab = v8::ArrayBuffer::New(isolate_, size_in_bytes, initialization_mode);
   buffer_ = static_cast<NativeT*>(ab->Data());
 
   // allocate v8 TypedArray

--- a/src/aliased_buffer.h
+++ b/src/aliased_buffer.h
@@ -35,7 +35,8 @@ class AliasedBufferBase : public MemoryRetainer {
 
   AliasedBufferBase(v8::Isolate* isolate,
                     const size_t count,
-                    const AliasedBufferIndex* index = nullptr);
+                    const AliasedBufferIndex* index = nullptr,
+                    const v8::BackingStoreInitializationMode initialization_mode = v8::BackingStoreInitializationMode::kZeroInitialized);
 
   /**
    * Create an AliasedBufferBase over a sub-region of another aliased buffer.

--- a/src/env_properties.h
+++ b/src/env_properties.h
@@ -157,6 +157,7 @@
   V(fatal_exception_string, "_fatalException")                                 \
   V(fd_string, "fd")                                                           \
   V(fields_string, "fields")                                                   \
+  V(outgoing_headers_string, "outgoingHeaders")                               \
   V(file_string, "file")                                                       \
   V(filename_string, "filename")                                               \
   V(fingerprint256_string, "fingerprint256")                                   \

--- a/src/node_external_reference.h
+++ b/src/node_external_reference.h
@@ -55,6 +55,15 @@ using CFunctionCallbackWithUint8ArrayUint32Int64Bool =
                 bool);
 using CFunctionWithUint32 = uint32_t (*)(v8::Local<v8::Value>,
                                          const uint32_t input);
+
+using CFunctionReturnInt32 = int32_t (*)(v8::Local<v8::Object> unused);
+using CFunctionScopedReturnInt32 = int32_t (*)(v8::Local<v8::Value> unused,
+                                               v8::Local<v8::Value> receiver);
+
+using CFunctionScopedWithInt32ReturnInt32 = int32_t (*)(v8::Local<v8::Value> unused,
+                                                        v8::Local<v8::Value> receiver,
+                                                        const int32_t options);
+
 using CFunctionWithDoubleReturnDouble = double (*)(v8::Local<v8::Value>,
                                                    v8::Local<v8::Value>,
                                                    const double);
@@ -105,6 +114,9 @@ class ExternalReferenceRegistry {
   V(CFunctionWithDoubleReturnDouble)                                           \
   V(CFunctionWithInt64Fallback)                                                \
   V(CFunctionWithBool)                                                         \
+  V(CFunctionReturnInt32)                                                      \
+  V(CFunctionScopedReturnInt32)                                                \
+  V(CFunctionScopedWithInt32ReturnInt32)                                       \
   V(CFunctionBufferCopy)                                                       \
   V(CFunctionWriteString)                                                      \
   V(const v8::CFunctionInfo*)                                                  \
@@ -180,6 +192,7 @@ class ExternalReferenceRegistry {
   V(tty_wrap)                                                                  \
   V(udp_wrap)                                                                  \
   V(url)                                                                       \
+  V(http2)                                                                     \
   V(util)                                                                      \
   V(pipe_wrap)                                                                 \
   V(sea)                                                                       \

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -12,7 +12,7 @@
 #include "node_revert.h"
 #include "stream_base-inl.h"
 #include "util-inl.h"
-
+#include "node_debug.h"
 #include "nbytes.h"
 
 #include <algorithm>
@@ -52,6 +52,7 @@ namespace http2 {
 namespace {
 
 const char zero_bytes_256[256] = {};
+
 
 bool HasHttp2Observer(Environment* env) {
   AliasedUint32Array& observers = env->performance_state()->observers;
@@ -553,6 +554,7 @@ Http2Session::Http2Session(Http2State* http2_state,
                            Local<Object> wrap,
                            SessionType type)
     : AsyncWrap(http2_state->env(), wrap, AsyncWrap::PROVIDER_HTTP2SESSION),
+      outgoing_headers_(http2_state->env()->isolate(), 1024, nullptr, v8::BackingStoreInitializationMode::kUninitialized),
       js_fields_(http2_state->env()->isolate()),
       session_type_(type),
       http2_state_(http2_state) {
@@ -609,7 +611,11 @@ Http2Session::Http2Session(Http2State* http2_state,
 
   Local<Uint8Array> uint8_arr =
       Uint8Array::New(js_fields_.GetArrayBuffer(), 0, kSessionUint8FieldCount);
+
   USE(wrap->Set(env()->context(), env()->fields_string(), uint8_arr));
+
+  // this is for establishing request sessions
+  USE(wrap->Set(env()->context(), env()->outgoing_headers_string(), outgoing_headers_.GetJSArray()));
 }
 
 Http2Session::~Http2Session() {
@@ -650,6 +656,7 @@ void Http2Session::MemoryInfo(MemoryTracker* tracker) const {
   tracker->TrackField("outstanding_pings", outstanding_pings_);
   tracker->TrackField("outstanding_settings", outstanding_settings_);
   tracker->TrackField("outgoing_buffers", outgoing_buffers_);
+  tracker->TrackFieldWithSize("outgoing_headers", outgoing_headers_.Length());
   tracker->TrackFieldWithSize("stream_buf", stream_buf_.len);
   tracker->TrackFieldWithSize("outgoing_storage", outgoing_storage_.size());
   tracker->TrackFieldWithSize("pending_rst_streams",
@@ -1314,11 +1321,7 @@ int Http2Session::OnDataChunkReceived(nghttp2_session* handle,
     } else {
       memcpy(buf.base, data, avail);
     }
-    if (buf.base == nullptr) [[likely]] {
-      buf.base = reinterpret_cast<char*>(const_cast<uint8_t*>(data));
-    } else {
-      memcpy(buf.base, data, avail);
-    }
+
     data += avail;
     len -= avail;
     stream->EmitRead(avail, buf);
@@ -2011,7 +2014,7 @@ Http2Stream* Http2Session::SubmitRequest(
   Http2Scope h2scope(this);
   Http2Stream* stream = nullptr;
   Http2Stream::Provider::Stream prov(options);
-  *ret = nghttp2_submit_request(
+  *ret = nghttp2_submit_request2(
       session_.get(),
       &priority,
       headers.data(),
@@ -2020,6 +2023,7 @@ Http2Stream* Http2Session::SubmitRequest(
       nullptr);
   CHECK_NE(*ret, NGHTTP2_ERR_NOMEM);
   if (*ret > 0) [[likely]] {
+    // fprintf(stderr, "Http2Stream::New\n");
     stream = Http2Stream::New(this, *ret, NGHTTP2_HCAT_HEADERS, options);
   }
   return stream;
@@ -2160,6 +2164,8 @@ Http2Stream* Http2Stream::New(Http2Session* session,
            .ToLocal(&obj)) {
     return nullptr;
   }
+
+  // fprintf(stderr, "internal field count %d\n", obj->InternalFieldCount());
   return new Http2Stream(session, obj, id, category, options);
 }
 
@@ -2171,10 +2177,12 @@ Http2Stream::Http2Stream(Http2Session* session,
     : AsyncWrap(session->env(), obj, AsyncWrap::PROVIDER_HTTP2STREAM),
       StreamBase(session->env()),
       session_(session),
+      http2_state_(session->http2_state()),
       id_(id),
       current_headers_category_(category) {
   MakeWeak();
   StreamBase::AttachToObject(GetObject());
+  GetObject()->SetAlignedPointerInInternalField(Http2Stream::kImplField, this);
   statistics_.id = id;
   statistics_.start_time = uv_hrtime();
 
@@ -2327,7 +2335,7 @@ int Http2Stream::SubmitResponse(const Http2Headers& headers, int options) {
     options |= STREAM_OPTION_EMPTY_PAYLOAD;
 
   Http2Stream::Provider::Stream prov(this, options);
-  int ret = nghttp2_submit_response(
+  int ret = nghttp2_submit_response2(
       session_->session(),
       id_,
       headers.data(),
@@ -2377,7 +2385,7 @@ int Http2Stream::SubmitTrailers(const Http2Headers& headers) {
   // to indicate that the stream is ready to be closed.
   if (headers.length() == 0) {
     Http2Stream::Provider::Stream prov(this, 0);
-    ret = nghttp2_submit_data(
+    ret = nghttp2_submit_data2(
         session_->session(),
         NGHTTP2_FLAG_END_STREAM,
         id_,
@@ -2537,11 +2545,11 @@ int Http2Stream::DoWrite(WriteWrap* req_wrap,
   for (size_t i = 0; i < nbufs; ++i) {
     // Store the req_wrap on the last write info in the queue, so that it is
     // only marked as finished once all buffers associated with it are finished.
-    queue_.emplace(NgHttp2StreamWrite {
+    queue_.emplace(
       BaseObjectPtr<AsyncWrap>(
           i == nbufs - 1 ? req_wrap->GetAsyncWrap() : nullptr),
       bufs[i]
-    });
+    );
     IncrementAvailableOutboundLength(bufs[i].len);
   }
   CHECK_NE(nghttp2_session_resume_data(
@@ -2834,16 +2842,15 @@ void Http2Session::Request(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&session, args.This());
   Environment* env = session->env();
 
-  Local<Array> headers = args[0].As<Array>();
-  int32_t options = args[1]->Int32Value(env->context()).ToChecked();
+  int32_t options = args[0]->Int32Value(env->context()).ToChecked();
 
   Debug(session, "request submitted");
 
   int32_t ret = 0;
   Http2Stream* stream =
       session->Http2Session::SubmitRequest(
-          Http2Priority(env, args[2], args[3], args[4]),
-          Http2Headers(env, headers),
+          Http2Priority(env, args[1], args[2], args[3]),
+          Http2Headers(session->http2_state()->headers_buffer.GetNativeBuffer()),
           &ret,
           static_cast<int>(options));
 
@@ -2913,14 +2920,23 @@ void Http2Session::UpdateChunksSent(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(length);
 }
 
+// class Http2Stream Methods
+Http2Stream* Http2Stream::FromObject(Local<Object> obj) {
+  if (obj->GetAlignedPointerFromInternalField(StreamBase::kSlot) == nullptr)
+    return nullptr;
+
+  return static_cast<Http2Stream*>(obj->GetAlignedPointerFromInternalField(Http2Stream::kImplField));
+}
+
 // Submits an RST_STREAM frame effectively closing the Http2Stream. Note that
 // this *WILL* alter the state of the stream, causing the OnStreamClose
 // callback to the triggered.
 void Http2Stream::RstStream(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   Local<Context> context = env->context();
-  Http2Stream* stream;
-  ASSIGN_OR_RETURN_UNWRAP(&stream, args.This());
+
+  auto stream = Http2Stream::FromObject(args.This());
+
   uint32_t code = args[0]->Uint32Value(context).ToChecked();
   Debug(stream, "sending rst_stream with code %d", code);
   stream->SubmitRstStream(code);
@@ -2930,48 +2946,74 @@ void Http2Stream::RstStream(const FunctionCallbackInfo<Value>& args) {
 // outbound DATA frames.
 void Http2Stream::Respond(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
-  Http2Stream* stream;
-  ASSIGN_OR_RETURN_UNWRAP(&stream, args.This());
+  Http2Stream* stream = Http2Stream::FromObject(args[0].As<Object>());
 
-  Local<Array> headers = args[0].As<Array>();
+  // Local<Array> headers = args[0].As<Array>();
   int32_t options = args[1]->Int32Value(env->context()).ToChecked();
 
   args.GetReturnValue().Set(
       stream->SubmitResponse(
-          Http2Headers(env, headers),
+          Http2Headers(stream->http2_state_->headers_buffer.GetNativeBuffer()),
           static_cast<int>(options)));
+
   Debug(stream, "response submitted");
 }
 
+int32_t Http2Stream::FastRespond(Local<Value> unused,
+                                 Local<Value> receiver,
+                                 const int32_t options) {
+
+  TRACK_V8_FAST_API_CALL("http2.respond");
+
+  auto stream = Http2Stream::FromObject(receiver.As<Object>());
+
+  int32_t ret = stream->SubmitResponse(
+    Http2Headers(stream->http2_state_->headers_buffer.GetNativeBuffer()),
+    static_cast<int>(options));
+
+  return ret;
+}
 
 // Submits informational headers on the Http2Stream
 void Http2Stream::Info(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
   Http2Stream* stream;
   ASSIGN_OR_RETURN_UNWRAP(&stream, args.This());
 
-  Local<Array> headers = args[0].As<Array>();
-
-  args.GetReturnValue().Set(stream->SubmitInfo(Http2Headers(env, headers)));
+  args.GetReturnValue().Set(stream->SubmitInfo(
+    Http2Headers(stream->http2_state_->headers_buffer.GetNativeBuffer()))
+  );
 }
 
 // Submits trailing headers on the Http2Stream
 void Http2Stream::Trailers(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-  Http2Stream* stream;
-  ASSIGN_OR_RETURN_UNWRAP(&stream, args.This());
+  auto stream = Http2Stream::FromObject(args[0].As<Object>());
+  args.GetReturnValue().Set(stream->SubmitTrailers(
+    Http2Headers(stream->http2_state_->headers_buffer.GetNativeBuffer())
+  ));
+}
 
-  Local<Array> headers = args[0].As<Array>();
+int32_t Http2Stream::FastTrailers(Local<Value> unused, Local<Value> receiver) {
+  TRACK_V8_FAST_API_CALL("http2.trailers");
 
-  args.GetReturnValue().Set(
-      stream->SubmitTrailers(Http2Headers(env, headers)));
+  auto stream = Http2Stream::FromObject(receiver.As<Object>());
+  auto ret = stream->SubmitTrailers(
+    Http2Headers(stream->http2_state_->headers_buffer.GetNativeBuffer())
+  );
+
+  return ret;
 }
 
 // Grab the numeric id of the Http2Stream
 void Http2Stream::GetID(const FunctionCallbackInfo<Value>& args) {
-  Http2Stream* stream;
-  ASSIGN_OR_RETURN_UNWRAP(&stream, args.This());
+  auto stream = Http2Stream::FromObject(args[0].As<Object>());
   args.GetReturnValue().Set(stream->id());
+}
+
+int32_t Http2Stream::FastGetID(Local<Value> unused, Local<Value> receiver) {
+  TRACK_V8_FAST_API_CALL("http2.get-id");
+
+  auto stream = Http2Stream::FromObject(receiver.As<Object>());
+  return stream->id();
 }
 
 // Destroy the Http2Stream, rendering it no longer usable
@@ -2988,15 +3030,14 @@ void Http2Stream::PushPromise(const FunctionCallbackInfo<Value>& args) {
   Http2Stream* parent;
   ASSIGN_OR_RETURN_UNWRAP(&parent, args.This());
 
-  Local<Array> headers = args[0].As<Array>();
-  int32_t options = args[1]->Int32Value(env->context()).ToChecked();
+  int32_t options = args[0]->Int32Value(env->context()).ToChecked();
 
   Debug(parent, "creating push promise");
 
   int32_t ret = 0;
   Http2Stream* stream =
       parent->SubmitPushPromise(
-          Http2Headers(env, headers),
+          Http2Headers(parent->session()->http2_state()->headers_buffer.GetNativeBuffer()),
           &ret,
           static_cast<int>(options));
 
@@ -3314,17 +3355,94 @@ void NgHttp2Debug(const char* format, va_list args) {
 
 void Http2State::MemoryInfo(MemoryTracker* tracker) const {
   tracker->TrackField("root_buffer", root_buffer);
+  tracker->TrackField("headers_buffer", headers_buffer);
+}
+
+bool Http2State::PrepareForSerialization(v8::Local<v8::Context> context,
+                                         v8::SnapshotCreator* creator) {
+  // We'll just re-initialize the buffers in the constructor since their
+  // contents can be thrown away once consumed in the previous call.
+  headers_buffer.Release();
+  // Return true because we need to maintain the reference to the binding from
+  // JS land.
+  return true;
+}
+
+InternalFieldInfoBase* Http2State::Serialize(int index) {
+  DCHECK_IS_SNAPSHOT_SLOT(index);
+  InternalFieldInfo* info =
+      InternalFieldInfoBase::New<InternalFieldInfo>(type());
+  return info;
+}
+
+void Http2State::Deserialize(v8::Local<v8::Context> context,
+                              v8::Local<v8::Object> holder,
+                              int index,
+                              InternalFieldInfoBase* info) {
+  DCHECK_IS_SNAPSHOT_SLOT(index);
+  v8::HandleScope scope(context->GetIsolate());
+  Realm* realm = Realm::GetCurrent(context);
+  Http2State* binding = realm->AddBindingData<Http2State>(holder);
+  CHECK_NOT_NULL(binding);
+}
+
+void Http2State::IncreaseBuffer(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  Realm* realm = Realm::GetCurrent(args);
+  Http2State* binding_data = realm->GetBindingData<Http2State>();
+  Isolate* isolate = realm->isolate();
+
+  size_t size = args[0]->Uint32Value(isolate->GetCurrentContext()).ToChecked();
+  auto increased_buffer = binding_data->UpdateHeadersBuffer(size);
+
+  // update references
+  binding_data->object()
+      ->Set(realm->context(),
+            realm->env()->outgoing_headers_string(),
+            increased_buffer)
+      .Check();
+}
+
+v8::Local<v8::Uint8Array> Http2State::UpdateHeadersBuffer(const size_t capacity) {
+  headers_buffer.reserve(capacity);
+  return headers_buffer.GetJSArray();
+}
+
+// Fast API Calls
+
+v8::CFunction Http2Stream::fast_respond_(
+    v8::CFunction::Make(&Http2Stream::FastRespond));
+v8::CFunction Http2Stream::fast_trailers_(
+    v8::CFunction::Make(&Http2Stream::FastTrailers));
+v8::CFunction Http2Stream::fast_get_id_(
+    v8::CFunction::Make(&Http2Stream::FastGetID));
+
+void Http2Stream::RegisterExternalReferences(ExternalReferenceRegistry *registry) {
+  registry->Register(Respond);
+  registry->Register(FastRespond);
+  registry->Register(fast_respond_.GetTypeInfo());
+
+  registry->Register(Trailers);
+  registry->Register(FastTrailers);
+  registry->Register(fast_trailers_.GetTypeInfo());
+
+  registry->Register(GetID);
+  registry->Register(FastGetID);
+  registry->Register(fast_get_id_.GetTypeInfo());
 }
 
 // Set up the process.binding('http2') binding.
-void Initialize(Local<Object> target,
-                Local<Value> unused,
-                Local<Context> context,
-                void* priv) {
+void Http2State::CreatePerContextProperties(Local<Object> target,
+                                            Local<Value> unused,
+                                            Local<Context> context,
+                                            void* priv) {
   Realm* realm = Realm::GetCurrent(context);
   Environment* env = realm->env();
   Isolate* isolate = env->isolate();
   HandleScope handle_scope(isolate);
+
+  SetFastMethod(context, target, "respondStatic", Http2Stream::Respond, &Http2Stream::fast_respond_);
+  SetFastMethod(context, target, "trailersStatic", Http2Stream::Trailers, &Http2Stream::fast_trailers_);
+  SetFastMethod(context, target, "idStatic", Http2Stream::GetID, &Http2Stream::fast_get_id_);
 
   Http2State* const state = realm->AddBindingData<Http2State>(target);
   if (state == nullptr) return;
@@ -3367,37 +3485,39 @@ void Initialize(Local<Object> target,
   SetMethod(context, target, "refreshDefaultSettings", RefreshDefaultSettings);
   SetMethod(context, target, "packSettings", PackSettings);
   SetMethod(context, target, "setCallbackFunctions", SetCallbackFunctions);
+  SetMethod(context, target, "increaseBuffer", IncreaseBuffer);
 
-  Local<FunctionTemplate> ping = FunctionTemplate::New(env->isolate());
-  ping->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "Http2Ping"));
+// Http2Ping
+  Local<FunctionTemplate> ping = FunctionTemplate::New(isolate);
+  ping->SetClassName(FIXED_ONE_BYTE_STRING(isolate, "Http2Ping"));
   ping->Inherit(AsyncWrap::GetConstructorTemplate(env));
   Local<ObjectTemplate> pingt = ping->InstanceTemplate();
   pingt->SetInternalFieldCount(Http2Ping::kInternalFieldCount);
   env->set_http2ping_constructor_template(pingt);
 
-  Local<FunctionTemplate> setting = FunctionTemplate::New(env->isolate());
+  // Http2Settings
+  Local<FunctionTemplate> setting = FunctionTemplate::New(isolate);
   setting->Inherit(AsyncWrap::GetConstructorTemplate(env));
   Local<ObjectTemplate> settingt = setting->InstanceTemplate();
   settingt->SetInternalFieldCount(AsyncWrap::kInternalFieldCount);
   env->set_http2settings_constructor_template(settingt);
 
-  Local<FunctionTemplate> stream = FunctionTemplate::New(env->isolate());
-  SetProtoMethod(isolate, stream, "id", Http2Stream::GetID);
+  // Http2Stream
+  Local<FunctionTemplate> stream = FunctionTemplate::New(isolate);
   SetProtoMethod(isolate, stream, "destroy", Http2Stream::Destroy);
   SetProtoMethod(isolate, stream, "priority", Http2Stream::Priority);
   SetProtoMethod(isolate, stream, "pushPromise", Http2Stream::PushPromise);
   SetProtoMethod(isolate, stream, "info", Http2Stream::Info);
-  SetProtoMethod(isolate, stream, "trailers", Http2Stream::Trailers);
-  SetProtoMethod(isolate, stream, "respond", Http2Stream::Respond);
   SetProtoMethod(isolate, stream, "rstStream", Http2Stream::RstStream);
   SetProtoMethod(isolate, stream, "refreshState", Http2Stream::RefreshState);
   stream->Inherit(AsyncWrap::GetConstructorTemplate(env));
   StreamBase::AddMethods(env, stream);
   Local<ObjectTemplate> streamt = stream->InstanceTemplate();
-  streamt->SetInternalFieldCount(StreamBase::kInternalFieldCount);
+  streamt->SetInternalFieldCount(Http2Stream::kInternalFieldCount);
   env->set_http2stream_constructor_template(streamt);
   SetConstructorFunction(context, target, "Http2Stream", stream);
 
+  // Http2Session
   Local<FunctionTemplate> session =
       NewFunctionTemplate(isolate, Http2Session::New);
   session->InstanceTemplate()->SetInternalFieldCount(
@@ -3432,6 +3552,7 @@ void Initialize(Local<Object> target,
                                     false>);
   SetConstructorFunction(context, target, "Http2Session", session);
 
+  // Constants to be exported
   Local<Object> constants = Object::New(isolate);
 
   // This does allocate one more slot than needed but it's not used.
@@ -3484,7 +3605,15 @@ void Initialize(Local<Object> target,
   nghttp2_set_debug_vprintf_callback(NgHttp2Debug);
 #endif
 }
+
+void Http2State::RegisterExternalReferences(ExternalReferenceRegistry* registry) {
+  Http2Stream::RegisterExternalReferences(registry);
+}
+
 }  // namespace http2
 }  // namespace node
 
-NODE_BINDING_CONTEXT_AWARE_INTERNAL(http2, node::http2::Initialize)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(
+    http2, node::http2::Http2State::CreatePerContextProperties)
+NODE_BINDING_EXTERNAL_REFERENCE(
+    http2, node::http2::Http2State::RegisterExternalReferences)

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -16,12 +16,19 @@
 #include "node_perf.h"
 #include "stream_base.h"
 #include "string_bytes.h"
+#include "v8-fast-api-calls.h"
 
 #include <algorithm>
 #include <queue>
 
 namespace node {
+
+class ExternalReferenceRegistry;
 namespace http2 {
+
+using v8::Local;
+using v8::Value;
+using v8::Object;
 
 // Constants in all caps are exported as user-facing constants
 // in JavaScript. Constants using the kName pattern are internal
@@ -245,9 +252,9 @@ class Http2Options {
 
 struct Http2Priority : public nghttp2_priority_spec {
   Http2Priority(Environment* env,
-                v8::Local<v8::Value> parent,
-                v8::Local<v8::Value> weight,
-                v8::Local<v8::Value> exclusive);
+                Local<Value> parent,
+                Local<Value> weight,
+                Local<Value> exclusive);
 };
 
 class Http2StreamListener : public StreamListener {
@@ -270,6 +277,15 @@ using Http2Header = NgHeader<Http2HeaderTraits>;
 class Http2Stream : public AsyncWrap,
                     public StreamBase {
  public:
+  // The kSlot field here mirrors that of BaseObject::InternalFields::kSlot
+  // because instances deriving from StreamBase generally also derived from
+  // BaseObject (it's possible for it not to, however).
+  enum InternalFields {
+    kSlot = BaseObject::kSlot,
+    kImplField = StreamBase::kInternalFieldCount,
+    kInternalFieldCount
+  };
+
   static Http2Stream* New(
       Http2Session* session,
       int32_t id,
@@ -319,7 +335,6 @@ class Http2Stream : public AsyncWrap,
       const Http2Headers& headers,
       int32_t* ret,
       int options = 0);
-
 
   void Close(int32_t code);
 
@@ -440,16 +455,36 @@ class Http2Stream : public AsyncWrap,
 
   std::string diagnostic_name() const override;
 
+  // Init API
+  static void RegisterExternalReferences(ExternalReferenceRegistry *registry);
+  static void AddMethods(v8::Isolate* isolate,
+                         v8::Local<v8::FunctionTemplate> target);
+
   // JavaScript API
-  static void GetID(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void Destroy(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void Priority(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void PushPromise(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void RefreshState(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void Info(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void Trailers(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void Respond(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void RstStream(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void Destroy(const v8::FunctionCallbackInfo<Value>& args);
+  static void Priority(const v8::FunctionCallbackInfo<Value>& args);
+  static void PushPromise(const v8::FunctionCallbackInfo<Value>& args);
+  static void RefreshState(const v8::FunctionCallbackInfo<Value>& args);
+  static void Info(const v8::FunctionCallbackInfo<Value>& args);
+  static void RstStream(const v8::FunctionCallbackInfo<Value>& args);
+
+  // Slow API
+  static void GetID(const v8::FunctionCallbackInfo<Value>& args);
+  static void Trailers(const v8::FunctionCallbackInfo<Value>& args);
+  static void Respond(const v8::FunctionCallbackInfo<Value>& args);
+
+  // Fast JavaScript API
+  static int32_t FastRespond(Local<Value> unused, Local<Value> receiver, const int32_t options);
+  static int32_t FastTrailers(Local<Value> unused, Local<Value> receiver);
+  static int32_t FastGetID(Local<Value> unused, Local<Value> receiver);
+
+  // fast api references for JS API
+  static v8::CFunction fast_respond_;
+  static v8::CFunction fast_trailers_;
+  static v8::CFunction fast_get_id_;
+
+  // get type checked embedder
+  static inline Http2Stream* FromObject(Local<Object> value);
 
   class Provider;
 
@@ -476,6 +511,8 @@ class Http2Stream : public AsyncWrap,
   void EmitStatistics();
 
   BaseObjectWeakPtr<Http2Session> session_;     // The Parent HTTP/2 Session
+  BaseObjectWeakPtr<Http2State> http2_state_;
+
   int32_t id_ = 0;                              // The Stream Identifier
   int32_t code_ = NGHTTP2_NO_ERROR;             // The RST_STREAM code (if any)
   int flags_ = kStreamStateNone;        // Internal state flags
@@ -512,14 +549,14 @@ class Http2Stream::Provider {
   explicit Provider(int options);
   virtual ~Provider();
 
-  nghttp2_data_provider* operator*() {
+  nghttp2_data_provider2* operator*() {
     return !empty_ ? &provider_ : nullptr;
   }
 
   class FD;
   class Stream;
  protected:
-  nghttp2_data_provider provider_;
+  nghttp2_data_provider2 provider_;
 
  private:
   bool empty_ = false;
@@ -723,6 +760,7 @@ class Http2Session : public AsyncWrap,
   static void Ping(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void AltSvc(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Origin(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void IncreaseBuffer(const v8::FunctionCallbackInfo<v8::Value>& args);
 
   template <get_setting fn, bool local>
   static void RefreshSettings(const v8::FunctionCallbackInfo<v8::Value>& args);
@@ -784,6 +822,7 @@ class Http2Session : public AsyncWrap,
   };
 
   Statistics statistics_ = {};
+  AliasedUint8Array outgoing_headers_;
 
  private:
   void EmitStatistics();

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -822,7 +822,6 @@ class Http2Session : public AsyncWrap,
   };
 
   Statistics statistics_ = {};
-  AliasedUint8Array outgoing_headers_;
 
  private:
   void EmitStatistics();

--- a/src/node_http_common.h
+++ b/src/node_http_common.h
@@ -252,6 +252,7 @@ class NgHeaders {
  public:
   typedef typename T::nv_t nv_t;
   inline NgHeaders(Environment* env, v8::Local<v8::Array> headers);
+  inline NgHeaders(const uint8_t* data);
   ~NgHeaders() = default;
 
   const nv_t* operator*() const {


### PR DESCRIPTION
- **util: add sourcemap support to getCallSites**
- **tools: use `util.parseArgs` in `lint-md`**
- **deps: update acorn to 8.14.0**
- **feat: use shared buffer to pass headers data, fast api calls**
